### PR TITLE
Add Importers Mockups

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,46 @@
+name: Storybook Deployment
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_call:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  gh-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build storybook
+        run: npm run build-storybook
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./storybook-static"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dist
 *storybook.log
 
 storybook-static/
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dist
 .pnp.*
 
 *storybook.log
+
+storybook-static/

--- a/src/app/Importers/ImportersPage.tsx
+++ b/src/app/Importers/ImportersPage.tsx
@@ -1,372 +1,106 @@
+import React, { Fragment } from 'react';
+
 import {
   Content,
-  Flex,
-  FlexItem,
-  Menu,
-  MenuContent,
-  MenuItem,
-  MenuList,
   MenuToggle,
+  MenuToggleElement,
   PageSection,
-  Pagination,
-  PaginationVariant,
-  Popper,
   SearchInput,
+  Select,
+  SelectList,
+  SelectOption,
   Toolbar,
   ToolbarContent,
-  ToolbarFilter,
   ToolbarGroup,
   ToolbarItem,
   ToolbarToggleGroup,
-  Tooltip,
 } from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
-import { Table, Thead, Tr, Th, Tbody, Td, ActionsColumn } from '@patternfly/react-table';
-import * as React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { rows, columns, ImportersDataRow } from './Importers.data';
-import ShieldIcon from '@patternfly/react-icons/dist/esm/icons/shield-alt-icon';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 
-export interface IImportersPageProps {
-  sampleProp?: string;
-}
+import { ImporterDataList } from './components/ImporterDataList';
 
-type Direction = 'asc' | 'desc' | undefined;
+const ImportersPage = () => {
+  const [typeIsExpanded, setTypeIsExpanded] = React.useState(false);
+  const [typeSelected, setTypeSelected] = React.useState('');
 
-const capitalizeFirstLetter = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
-
-const ImportersPage = ({}: IImportersPageProps) => {
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
-  const [searchValue, setSearchValue] = useState('');
-  const [searchCvssValue, setSearchCvssValue] = useState('');
-
-  const onSearchChange = (value: string) => {
-    setSearchValue(value);
-  };
-
-  const onSearchCvssChange = (value: string) => {
-    setSearchCvssValue(value);
-  };
-
-  const handleSetPage = (_evt: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handlePerPageSelect = (_evt: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number) => {
-    setPerPage(newPerPage);
-  };
-
-  const renderPagination = (variant: 'top' | 'bottom' | PaginationVariant, isCompact: boolean) => (
-    <Pagination
-      isCompact={isCompact}
-      itemCount={rows.length}
-      page={page}
-      perPage={perPage}
-      onSetPage={handleSetPage}
-      onPerPageSelect={handlePerPageSelect}
-      perPageOptions={[
-        { title: '10', value: 10 },
-        { title: '20', value: 20 },
-        { title: '50', value: 50 },
-        { title: '100', value: 100 },
-      ]}
-      variant={variant}
-      titles={{
-        paginationAriaLabel: `${variant} pagination`,
-      }}
-    />
-  );
-
-  // Table sorting
-
-  const sortRows = (rows: ImportersDataRow[], sortIndex: number, sortDirection: Direction) => {
-    return [...rows].sort((a, b) => {
-      let returnValue = 0;
-
-      if (typeof Object.values(a)[sortIndex] === 'number') {
-        // numeric sort
-        returnValue = Object.values(a)[sortIndex] - Object.values(b)[sortIndex];
-      } else {
-        // string sort
-        returnValue = Object.values(a)[sortIndex].localeCompare(Object.values(b)[sortIndex]);
-      }
-      if (sortDirection === 'desc') {
-        return returnValue * -1;
-      }
-      return returnValue;
-    });
-  };
-
-  const [sortedData, setSortedData] = useState([...sortRows(rows, 0, 'asc')]);
-  const [sortedRows, setSortedRows] = useState([...sortedData]);
-
-  // index of the currently active column
-  const [activeSortIndex, setActiveSortIndex] = useState(0);
-  // sort direction of the currently active column
-  const [activeSortDirection, setActiveSortDirection] = useState<Direction>('asc');
-
-  const onSort = (_event: any, index: number, direction: Direction) => {
-    setActiveSortIndex(index);
-    setActiveSortDirection(direction);
-
-    setSortedData(sortRows(rows, index, direction));
-  };
-
-  useEffect(() => {
-    setSortedRows(sortedData.slice((page - 1) * perPage, page * perPage));
-  }, [sortedData, page, perPage]);
-
-  const getFilteredAndSortedRows = useCallback(() => {
-    let filtered = rows;
-    if (searchCvssValue) {
-      const input = new RegExp(searchCvssValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-      filtered = rows.filter((row) => input.test(row.identifier));
-    }
-
-    if (searchValue) {
-      const input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-      filtered = rows.filter((row) => input.test(row.title));
-    }
-
-    return [...filtered].sort((a, b) => {
-      const aVal = Object.values(a)[activeSortIndex];
-      const bVal = Object.values(b)[activeSortIndex];
-      let result = 0;
-
-      if (typeof aVal === 'number' && typeof bVal === 'number') {
-        result = aVal - bVal;
-      } else if (typeof aVal === 'string' && typeof bVal === 'string') {
-        result = aVal.localeCompare(bVal);
-      }
-
-      return activeSortDirection === 'desc' ? -result : result;
-    });
-  }, [searchValue, searchCvssValue, activeSortIndex, activeSortDirection]);
-
-  useEffect(() => {
-    const filteredSorted = getFilteredAndSortedRows();
-    setSortedData(filteredSorted);
-    setSortedRows(filteredSorted.slice((page - 1) * perPage, page * perPage));
-  }, [getFilteredAndSortedRows, page, perPage]);
-
-  // Set up attribute selector
-  const [activeAttributeMenu, setActiveAttributeMenu] = useState<'Filter text' | 'CVSS' | 'Revision'>('Filter text');
-  const [isAttributeMenuOpen, setIsAttributeMenuOpen] = useState(false);
-  const attributeToggleRef = useRef<HTMLButtonElement>(null);
-  const attributeMenuRef = useRef<HTMLDivElement>(null);
-  const attributeContainerRef = useRef<HTMLDivElement>(null);
-
-  const handleAttribueMenuKeys = (event: KeyboardEvent) => {
-    if (!isAttributeMenuOpen) {
-      return;
-    }
-    if (
-      attributeMenuRef.current?.contains(event.target as Node) ||
-      attributeToggleRef.current?.contains(event.target as Node)
-    ) {
-      if (event.key === 'Escape' || event.key === 'Tab') {
-        setIsAttributeMenuOpen(!isAttributeMenuOpen);
-        attributeToggleRef.current?.focus();
-      }
-    }
-  };
-
-  const handleAttributeClickOutside = (event: MouseEvent) => {
-    if (isAttributeMenuOpen && !attributeMenuRef.current?.contains(event.target as Node)) {
-      setIsAttributeMenuOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('keydown', handleAttribueMenuKeys);
-    window.addEventListener('click', handleAttributeClickOutside);
-    return () => {
-      window.removeEventListener('keydown', handleAttribueMenuKeys);
-      window.removeEventListener('click', handleAttributeClickOutside);
-    };
-  }, [isAttributeMenuOpen, attributeMenuRef]);
-
-  const onAttributeToggleClick = (ev: React.MouseEvent) => {
-    ev.stopPropagation(); // Stop handleClickOutside from handling
-    setTimeout(() => {
-      if (attributeMenuRef.current) {
-        const firstElement = attributeMenuRef.current.querySelector('li > button:not(:disabled)');
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        firstElement && (firstElement as HTMLElement).focus();
-      }
-    }, 0);
-    setIsAttributeMenuOpen(!isAttributeMenuOpen);
-  };
-
-  const attributeToggle = (
-    <MenuToggle
-      ref={attributeToggleRef}
-      onClick={onAttributeToggleClick}
-      isExpanded={isAttributeMenuOpen}
-      icon={<FilterIcon />}
-    >
-      {activeAttributeMenu}
-    </MenuToggle>
-  );
-
-  const attributeMenu = (
-    <Menu
-      ref={attributeMenuRef}
-      onSelect={(_ev, itemId) => {
-        setActiveAttributeMenu(itemId?.toString() as 'Filter text' | 'Revision');
-        setIsAttributeMenuOpen(!isAttributeMenuOpen);
-      }}
-    >
-      <MenuContent>
-        <MenuList>
-          <MenuItem itemId="Filter text">Filter text</MenuItem>
-          <MenuItem itemId="CVSS">CVSS</MenuItem>
-          <MenuItem itemId="Created on">Created on</MenuItem>
-        </MenuList>
-      </MenuContent>
-    </Menu>
-  );
-
-  const attributeDropdown = (
-    <div ref={attributeContainerRef}>
-      <Popper
-        trigger={attributeToggle}
-        triggerRef={attributeToggleRef}
-        popper={attributeMenu}
-        popperRef={attributeMenuRef}
-        appendTo={attributeContainerRef.current || undefined}
-        isVisible={isAttributeMenuOpen}
-      />
-    </div>
-  );
-
-  // Set up identifier search input
-  const searchInput = (
-    <SearchInput
-      placeholder="Filter by text"
-      value={searchValue}
-      onChange={(_event, value) => onSearchChange(value)}
-      onClear={() => onSearchChange('')}
-    />
-  );
-
-  const toggleGroupItems = (
-    <ToolbarGroup variant="filter-group">
-      <ToolbarItem>{attributeDropdown}</ToolbarItem>
-      <ToolbarFilter
-        labels={searchValue !== '' ? [searchValue] : ([] as string[])}
-        deleteLabel={() => setSearchValue('')}
-        deleteLabelGroup={() => setSearchValue('')}
-        categoryName="Title"
-        showToolbarItem={activeAttributeMenu === 'Filter text'}
-      >
-        {searchInput}
-      </ToolbarFilter>
-      <ToolbarFilter categoryName={'Revision'} showToolbarItem={activeAttributeMenu === 'Revision'}>
-        Some dropdown will go here
-      </ToolbarFilter>
-      <ToolbarItem variant="pagination">{renderPagination('top', true)}</ToolbarItem>
-    </ToolbarGroup>
-  );
-
-  const toolbarItems = (
-    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
-      {toggleGroupItems}
-    </ToolbarToggleGroup>
-  );
+  const [statusIsExpanded, setStatusIsExpanded] = React.useState(false);
+  const [statusSelected, setStatusSelected] = React.useState('');
 
   return (
-    <>
-      <PageSection>
+    <Fragment>
+      <PageSection variant="default">
         <Content>
-          <h1>Importers</h1>
+          <h1>Data sources</h1>
+          <p>Import SBOMs, Advisories, and Licenses.</p>
         </Content>
-        <Toolbar
-          id="attribute-search-filter-toolbar"
-          clearAllFilters={() => {
-            setSearchValue('');
-            setSearchCvssValue('');
-          }}
-        >
-          <ToolbarContent>{toolbarItems}</ToolbarContent>
+      </PageSection>
+      <PageSection variant="default">
+        <Toolbar id="toolbar-group-types">
+          <ToolbarContent>
+            <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+              <ToolbarItem>
+                <SearchInput />
+              </ToolbarItem>
+              <ToolbarGroup variant="filter-group">
+                <ToolbarItem>
+                  <Select
+                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        onClick={() => setTypeIsExpanded(!typeIsExpanded)}
+                        isExpanded={typeIsExpanded}
+                      >
+                        {typeSelected || 'Type'}
+                      </MenuToggle>
+                    )}
+                    onSelect={(_e, selection) => {
+                      setTypeSelected(selection as string);
+                      setTypeIsExpanded(false);
+                    }}
+                    onOpenChange={(isOpen) => setTypeIsExpanded(isOpen)}
+                    selected={typeSelected}
+                    isOpen={typeIsExpanded}
+                  >
+                    <SelectList>
+                      <SelectOption value="SBOM">SBOM</SelectOption>
+                      <SelectOption value="Advisory">Advisory</SelectOption>
+                      <SelectOption value="License">License</SelectOption>
+                    </SelectList>
+                  </Select>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Select
+                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        onClick={() => setStatusIsExpanded(!statusIsExpanded)}
+                        isExpanded={statusIsExpanded}
+                      >
+                        {statusSelected || 'Status'}
+                      </MenuToggle>
+                    )}
+                    onSelect={(_e, selection) => {
+                      setStatusSelected(selection as string);
+                      setStatusIsExpanded(false);
+                    }}
+                    onOpenChange={(isOpen) => setStatusIsExpanded(isOpen)}
+                    selected={statusSelected}
+                    isOpen={statusIsExpanded}
+                  >
+                    <SelectList>
+                      <SelectOption value="Scheduled">Scheduled</SelectOption>
+                      <SelectOption value="Running">Running</SelectOption>
+                      <SelectOption value="Disabled">Disabled</SelectOption>
+                    </SelectList>
+                  </Select>
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarToggleGroup>
+          </ToolbarContent>
         </Toolbar>
+        <ImporterDataList />
       </PageSection>
-      <PageSection>
-        <Table aria-label="Sortable Table">
-          <Thead>
-            <Tr>
-              {columns.map((column, columnIndex) => {
-                const sortParams = {
-                  sort: {
-                    sortBy: {
-                      index: activeSortIndex,
-                      direction: activeSortDirection,
-                    },
-                    onSort,
-                    columnIndex,
-                  },
-                };
-                return (
-                  <Th modifier={columnIndex !== 6 ? 'wrap' : undefined} key={columnIndex} {...sortParams}>
-                    {column}
-                  </Th>
-                );
-              })}
-            </Tr>
-          </Thead>
-          <Tbody>
-            {sortedRows.map((row, rowIndex) => (
-              <Tr key={rowIndex}>
-                <>
-                  <Td dataLabel={columns[0]} width={15}>
-                    <div>{row.name}</div>
-                  </Td>
-                  <Td dataLabel={columns[1]} width={15} modifier={'truncate'}>
-                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                      <FlexItem>{row.type}</FlexItem>
-                    </Flex>
-                  </Td>
-                  <Td dataLabel={columns[2]} width={10}>
-                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                      <FlexItem>{row.description}</FlexItem>
-                    </Flex>
-                  </Td>
-                  <Td dataLabel={columns[4]} width={10}>
-                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                      <FlexItem>{row.source}</FlexItem>
-                    </Flex>
-                  </Td>
-                  <Td dataLabel={columns[4]} width={10}>
-                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                      <FlexItem>{row.period}</FlexItem>
-                    </Flex>
-                  </Td>
-                  <Td dataLabel={columns[5]} width={10}>
-                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                      <FlexItem>{row.state}</FlexItem>
-                    </Flex>
-                  </Td>
-                  <Td dataLabel={columns[6]} isActionCell>
-                    <ActionsColumn
-                      items={[
-                        {
-                          title: 'Enable',
-                          onClick: () => {
-                            console.log('Enable button clicked');
-                          },
-                        },
-                      ]}
-                    />
-                  </Td>
-                </>
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-        {renderPagination('bottom', false)}
-      </PageSection>
-    </>
+    </Fragment>
   );
 };
 

--- a/src/app/Importers/components/ImporterDataList.tsx
+++ b/src/app/Importers/components/ImporterDataList.tsx
@@ -203,7 +203,7 @@ const ImporterDataList = () => {
           />
         )}
         isOpen={false}
-        onOpenChange={(isOpen: boolean) => {}}
+        onOpenChange={() => {}}
       >
         <DropdownList>
           <DropdownItem>Action1</DropdownItem>
@@ -215,13 +215,7 @@ const ImporterDataList = () => {
 
   return (
     <Fragment>
-      <Drawer
-        isExpanded={isDrawerExpanded}
-        onExpand={() => {
-          drawerRef.current;
-        }}
-        position="end"
-      >
+      <Drawer isExpanded={isDrawerExpanded} onExpand={() => {}} position="end">
         <DrawerContent
           panelContent={
             <DrawerPanelContent
@@ -232,6 +226,7 @@ const ImporterDataList = () => {
               minSize={'150px'}
             >
               <DrawerHead>
+                {/* eslint-disable @typescript-eslint/no-explicit-any */}
                 <div tabIndex={isDrawerExpanded ? 0 : -1} ref={drawerRef as any}>
                   <Content component="small">Name</Content>
                   <Content component="p">Data Source Name</Content>

--- a/src/app/Importers/components/ImporterDataList.tsx
+++ b/src/app/Importers/components/ImporterDataList.tsx
@@ -1,0 +1,278 @@
+import React, { Fragment } from 'react';
+
+import {
+  Content,
+  DataList,
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelContent,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Flex,
+  FlexItem,
+  Icon,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  Progress,
+  ProgressSize,
+} from '@patternfly/react-core';
+import {
+  CalendarAltIcon,
+  ClockIcon,
+  EllipsisVIcon,
+  FileAltIcon,
+  MinusIcon,
+  RunningIcon,
+} from '@patternfly/react-icons';
+
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
+import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
+import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
+
+import { ImporterDrawerContent } from './ImporterDrawerContent';
+
+const ImporterDataList = () => {
+  const [selectedRow, setSelectedRow] = React.useState('');
+
+  const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
+
+  const getRow = (id: string, lastStatus: 'success' | 'error' | null, isRunning: boolean, isDisabled: boolean) => {
+    let mainIcon;
+    let lastStatusComponent;
+    let currentStatus;
+
+    if (lastStatus === 'success') {
+      mainIcon = (
+        <Icon size="xl" status="success">
+          <CheckCircleIcon />
+        </Icon>
+      );
+    } else if (lastStatus === 'error') {
+      mainIcon = (
+        <Icon size="xl" status="danger">
+          <TimesCircleIcon />
+        </Icon>
+      );
+    } else {
+      mainIcon = (
+        <Icon size="xl">
+          <MinusIcon />
+        </Icon>
+      );
+    }
+
+    if (lastStatus === 'success' || lastStatus === 'error' || isRunning) {
+      lastStatusComponent = (
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem>
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <CalendarAltIcon /> 7 hours ago
+              </FlexItem>
+            </Flex>
+          </FlexItem>
+          <FlexItem>
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <ClockIcon /> 5 minutes
+              </FlexItem>
+            </Flex>
+          </FlexItem>
+          <FlexItem>
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <FileAltIcon /> 123456 documents
+              </FlexItem>
+            </Flex>
+          </FlexItem>
+        </Flex>
+      );
+    }
+
+    if (isRunning) {
+      mainIcon = (
+        <Icon size="xl" status="info">
+          <InProgressIcon />
+        </Icon>
+      );
+    }
+    if (isRunning) {
+      currentStatus = <Progress title="Time remaining: 2 hours" value={33} size={ProgressSize.sm} />;
+    } else {
+      currentStatus = (
+        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <PendingIcon /> Scheduled
+          </FlexItem>
+        </Flex>
+      );
+    }
+
+    if (isDisabled) {
+      currentStatus = <Label color="orange">Disabled</Label>;
+    }
+
+    return (
+      <DataListItem id={id} aria-labelledby="Demo-item1">
+        <DataListItemRow>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="icon" isFilled={false}>
+                {mainIcon}
+              </DataListCell>,
+              <DataListCell key="info" isFilled={false}>
+                <Flex direction={{ default: 'column' }}>
+                  <FlexItem>
+                    <Content component="p">Data Source Name</Content>
+                  </FlexItem>
+                  <FlexItem>
+                    <Content component="dd">
+                      <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                        <FlexItem>
+                          <CodeBranchIcon /> https://github.com/organization/repository.git
+                        </FlexItem>
+                      </Flex>
+                    </Content>
+                  </FlexItem>
+                  <FlexItem>
+                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                      <FlexItem>
+                        <CubeIcon /> Advisory
+                      </FlexItem>
+                      <FlexItem>
+                        <CubeIcon /> OSV
+                      </FlexItem>
+                    </Flex>
+                  </FlexItem>
+                </Flex>
+              </DataListCell>,
+              <DataListCell key="description">
+                <Flex direction={{ default: 'column' }}>
+                  <FlexItem>
+                    <Content component="p">This is the description of the Data Source</Content>
+                  </FlexItem>
+                </Flex>
+              </DataListCell>,
+              <DataListCell key="status" alignRight>
+                {lastStatusComponent}
+              </DataListCell>,
+              <DataListCell key="progress" alignRight>
+                <Flex direction={{ default: 'column' }}>
+                  <FlexItem>
+                    <RunningIcon /> Every 5 hours
+                  </FlexItem>
+                  <FlexItem>{currentStatus}</FlexItem>
+                </Flex>
+              </DataListCell>,
+            ]}
+          />
+          {action}
+        </DataListItemRow>
+      </DataListItem>
+    );
+  };
+
+  const action = (
+    <DataListAction id="actions" aria-label="Actions" aria-labelledby="actions">
+      <Dropdown
+        popperProps={{ position: 'right' }}
+        onSelect={() => {}}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            isExpanded={false}
+            onClick={() => {}}
+            variant="plain"
+            aria-label="Data list with checkboxes, actions and additional cells example kebab toggle 2"
+            icon={<EllipsisVIcon />}
+          />
+        )}
+        isOpen={false}
+        onOpenChange={(isOpen: boolean) => {}}
+      >
+        <DropdownList>
+          <DropdownItem>Action1</DropdownItem>
+          <DropdownItem>Action2</DropdownItem>
+        </DropdownList>
+      </Dropdown>
+    </DataListAction>
+  );
+
+  return (
+    <Fragment>
+      <Drawer
+        isExpanded={isDrawerExpanded}
+        onExpand={() => {
+          drawerRef.current;
+        }}
+        position="end"
+      >
+        <DrawerContent
+          panelContent={
+            <DrawerPanelContent
+              isResizable
+              onResize={() => {}}
+              id="end-resize-panel"
+              defaultSize={'750px'}
+              minSize={'150px'}
+            >
+              <DrawerHead>
+                <div tabIndex={isDrawerExpanded ? 0 : -1} ref={drawerRef}>
+                  <Content component="small">Name</Content>
+                  <Content component="p">Data Source Name</Content>
+                </div>
+                <DrawerActions>
+                  <DrawerCloseButton
+                    onClick={() => {
+                      setIsDrawerExpanded(false);
+                      setSelectedRow('');
+                    }}
+                  />
+                </DrawerActions>
+              </DrawerHead>
+              <ImporterDrawerContent />
+            </DrawerPanelContent>
+          }
+        >
+          <DrawerContentBody>
+            <DataList
+              aria-label="Demo data list"
+              selectedDataListItemId={selectedRow}
+              onSelectDataListItem={(_e, id) => {
+                setSelectedRow(id);
+                setIsDrawerExpanded(true);
+              }}
+              onSelectableRowChange={(_e, id) => {
+                setSelectedRow(id);
+                setIsDrawerExpanded(true);
+              }}
+            >
+              {getRow('row-1', null, false, false)}
+              {getRow('row-2', null, true, false)}
+              {getRow('row-3', 'success', false, false)}
+              {getRow('row-4', 'error', false, false)}
+              {getRow('row-5', null, false, true)}
+            </DataList>
+          </DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </Fragment>
+  );
+};
+
+export { ImporterDataList };

--- a/src/app/Importers/components/ImporterDataList.tsx
+++ b/src/app/Importers/components/ImporterDataList.tsx
@@ -232,7 +232,7 @@ const ImporterDataList = () => {
               minSize={'150px'}
             >
               <DrawerHead>
-                <div tabIndex={isDrawerExpanded ? 0 : -1} ref={drawerRef}>
+                <div tabIndex={isDrawerExpanded ? 0 : -1} ref={drawerRef as any}>
                   <Content component="small">Name</Content>
                   <Content component="p">Data Source Name</Content>
                 </div>

--- a/src/app/Importers/components/ImporterDrawerContent.tsx
+++ b/src/app/Importers/components/ImporterDrawerContent.tsx
@@ -1,0 +1,55 @@
+import { Fragment } from 'react';
+
+import { Flex, FlexItem, Icon, Pagination, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+
+const ImporterDrawerContent = () => {
+  return (
+    <Fragment>
+      <Tabs defaultActiveKey={0} aria-label="Tabs in the uncontrolled example" role="region">
+        <Tab eventKey={0} title={<TabTitleText>Executions</TabTitleText>} aria-label="Uncontrolled ref content - users">
+          <Pagination itemCount={523} perPage={10} page={1} variant="top" />
+          <Table variant="compact">
+            <Thead>
+              <Tr>
+                <Th>Started</Th>
+                <Th>Finished</Th>
+                <Th>Documents</Th>
+                <Th>Status</Th>
+                <Th>Duration</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {[...Array(10).keys()].map((item) => (
+                <Tr key={item}>
+                  <Td>5 April, 2025 12:12:00</Td>
+                  <Td>5 April, 2025 12:12:00</Td>
+                  <Td>123456</Td>
+                  <Td>
+                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                      <FlexItem>
+                        <Icon status="success">
+                          <CheckCircleIcon />
+                        </Icon>{' '}
+                        Success
+                      </FlexItem>
+                    </Flex>
+                  </Td>
+                  <Td>Time remaining: 3 hours</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+          <Pagination itemCount={523} perPage={10} page={1} variant="bottom" />
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Info</TabTitleText>}>
+          More info about the Data Source
+        </Tab>
+      </Tabs>
+    </Fragment>
+  );
+};
+
+export { ImporterDrawerContent };

--- a/stories/Importers.stories.tsx
+++ b/stories/Importers.stories.tsx
@@ -1,15 +1,15 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { AppLayout } from "@app/AppLayout/AppLayout";
-import { ImportersPage } from "@app/Importers/ImportersPage";
+import { AppLayout } from '@app/AppLayout/AppLayout';
+import { ImportersPage } from '@app/Importers/ImportersPage';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
-  title: "Importers/Importers Page",
+  title: 'Importers/Importers Page',
   component: ImportersPage,
   decorators: [
     (Story) => (
-        <AppLayout>
-          <Story />
-        </AppLayout>
+      <AppLayout>
+        <Story />
+      </AppLayout>
     ),
   ],
 } satisfies Meta<typeof ImportersPage>;


### PR DESCRIPTION
This PR adds a proposal of how the new Importers Page might look like after the UI Revamp.

Rename `Importers` by `Data Sources` => I think `Importers` is an internal terminology that was leaked in the UI. The whole system data will be populated by the Importers and hence I thought it would make sense to rename it as something like `Data Sources`. Feedback is welcome.

- No Pagination and all importers are rendered in the page.
  - We will never deal with thousands of importers and I think it would be better to render all rows without limiting the user to see only the first 10 ones. Feedback is welcome :)
- We do not use a Table anymore but a DataList
  - To render more data condensed in a single row I think it would make sense to replace our old Table. Tables force us to render only one type of data per column
- Each row has an icon at the Left. That icon should indicate the latest outcome of any know execution of the Importers.
- Replace the Expandable area by a Left Drawer.

![Screenshot From 2025-04-16 14-45-28](https://github.com/user-attachments/assets/18336f18-5f07-411b-aa93-145c1416de8c)

![Screenshot From 2025-04-16 14-45-37](https://github.com/user-attachments/assets/b0145c3b-3638-4ee6-abb3-261193f54465)

![Screenshot From 2025-04-16 14-45-48](https://github.com/user-attachments/assets/a0f934cd-52da-4a23-812e-3e3fe3ec875d)

![Screenshot From 2025-04-16 14-45-50](https://github.com/user-attachments/assets/e6a3bef6-447a-4bf5-9440-16f70d64651d)

